### PR TITLE
updated build.zig, README.md, and .gitignore to support 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-cache/
+.zig-cache/
 zig-out/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Zig-based implementation of general-rank tensors! [1, 64)
 
+## Importing ZEIN
+
+1. Fetch ZEIN:
+
+`zig fetch --save git+https://github.com/andrewCodeDev/ZEIN#main`
+
+2. Add the module in your `build.zig`:
+
+```zig
+const zein = b.dependency("ZEIN", .{
+    .target = target,
+    .optimize = optimize,
+});
+
+exe.root_module.addImport("zein", zein.module("ZEIN"));
+```
+You can now add `const zein = @import("zein");` to your file.
+
 ## Using Tensor Objects
 
 Tensors can be created in the following way:

--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,7 @@ pub fn build(b: *std.Build) void {
     // define primary (static library) artifact
     const lib = b.addStaticLibrary(.{
         .name = "ZEIN",
-        .root_source_file = .{ .path = "src/root.zig" },
+        .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -16,11 +16,19 @@ pub fn build(b: *std.Build) void {
 
     // create secondary (unit testing) artifact
     const unit_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/root.zig" },
+        .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
     const run_tests = b.addRunArtifact(unit_tests);
+
+    // export ZEIN module so it can
+    // be used in other projects
+    _ = b.addModule("ZEIN", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
     // define test step dependency
     const test_step = b.step("test", "Run unit tests");


### PR DESCRIPTION
Wanted to use ZEIN, but noticed it needed some maintenance to get it to work with the (as of now) current stable Zig version (0.13.0), so I made some changes, mainly replaced `.{ .path = ...}` with `b.path("...")`, and added the module export so it can be imported by other people.